### PR TITLE
feat: Add open sources licenses section in About page

### DIFF
--- a/about/build.gradle.kts
+++ b/about/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(Libs.materialComponents)
     implementation(Libs.ktxCore)
     implementation(Libs.constraintLayout)
+    implementation(Libs.navigation)
 
     implementation(Libs.epoxy)
     kapt(Libs.epoxyProcessor)

--- a/about/src/main/java/com/haroldadmin/moonshot/about/AboutFragment.kt
+++ b/about/src/main/java/com/haroldadmin/moonshot/about/AboutFragment.kt
@@ -13,6 +13,7 @@ import com.haroldadmin.moonshot.about.views.aboutDetailCard
 import com.haroldadmin.moonshot.base.MoonShotFragment
 import com.haroldadmin.moonshot.base.simpleController
 import com.haroldadmin.moonshot.R as appR
+import androidx.navigation.fragment.findNavController
 
 class AboutFragment : MoonShotFragment() {
 
@@ -110,6 +111,18 @@ class AboutFragment : MoonShotFragment() {
                 onDetailClick { _ ->
                     Intent(Intent.ACTION_VIEW, Uri.parse(Links.PRIVACY_POLICY)).also { intent ->
                         startActivity(intent)
+                    }
+                }
+            }
+
+            aboutDetailCard {
+                id("licenses")
+                header(R.string.openSourceLicensesDetailHeader)
+                message(R.string.openSourceLicensesDetailMessage)
+                icon(R.drawable.ic_law)
+                onDetailClick { _ ->
+                    AboutFragmentDirections.viewLicenses().let {
+                        findNavController().navigate(it)
                     }
                 }
             }

--- a/about/src/main/java/com/haroldadmin/moonshot/about/Licenses.kt
+++ b/about/src/main/java/com/haroldadmin/moonshot/about/Licenses.kt
@@ -1,0 +1,23 @@
+package com.haroldadmin.moonshot.about
+
+val licenses = mapOf(
+    "Kotlin Programming Language" to "https://github.com/JetBrains/kotlin/blob/master/license/LICENSE.txt",
+    "Kotlin Coroutines" to "https://github.com/Kotlin/kotlinx.coroutines/blob/master/LICENSE.txt",
+    "Koin" to "https://github.com/InsertKoinIO/koin/blob/master/LICENSE",
+    "AndroidX" to "https://android.googlesource.com/platform/frameworks/support/+/androidx-master-dev/LICENSE.txt",
+    "Material Components for Android" to "https://github.com/material-components/material-components-android/blob/master/LICENSE",
+    "Vector" to "https://github.com/haroldadmin/Vector/blob/master/LICENSE",
+    "Epoxy" to "https://github.com/airbnb/epoxy/blob/master/LICENSE",
+    "Coil" to "https://github.com/coil-kt/coil/blob/master/LICENSE.txt",
+    "Lemniscate" to "https://github.com/VladimirWrites/Lemniscate/blob/master/LICENSE",
+    "Lottie" to "https://github.com/airbnb/lottie-android/blob/master/LICENSE",
+    "JodaTime" to "https://github.com/JodaOrg/joda-time/blob/master/LICENSE.txt",
+    "Retrofit" to "https://github.com/square/retrofit/blob/master/LICENSE.txt",
+    "OkHttp" to "https://github.com/square/okhttp/",
+    "NetworkResponseAdapter" to "https://github.com/haroldadmin/NetworkResponseAdapter/blob/master/LICENSE",
+    "Moshi" to "https://github.com/square/moshi/blob/master/LICENSE.txt",
+    "JUnit" to "https://junit.org/junit4/license.html",
+    "KotlinTest" to "https://github.com/kotlintest/kotlintest.git",
+    "MockK" to "https://github.com/mockk/mockk/blob/master/LICENSE",
+    "SpaceX-API" to "https://github.com/r-spacex/SpaceX-API/blob/master/LICENSE"
+)

--- a/about/src/main/java/com/haroldadmin/moonshot/about/LicensesFragment.kt
+++ b/about/src/main/java/com/haroldadmin/moonshot/about/LicensesFragment.kt
@@ -1,0 +1,49 @@
+package com.haroldadmin.moonshot.about
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.recyclerview.widget.DividerItemDecoration
+import androidx.recyclerview.widget.LinearLayoutManager
+import com.airbnb.epoxy.EpoxyController
+import com.airbnb.epoxy.EpoxyRecyclerView
+import com.haroldadmin.moonshot.about.views.licenseView
+import com.haroldadmin.moonshot.base.MoonShotFragment
+import com.haroldadmin.moonshot.base.simpleController
+
+class LicensesFragment: MoonShotFragment() {
+
+    private lateinit var rvLicenses: EpoxyRecyclerView
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
+        val root = inflater.inflate(R.layout.fragment_licenses, container, false)
+        rvLicenses = root.findViewById(R.id.rvLicenses)
+        rvLicenses.addItemDecoration(DividerItemDecoration(requireContext(), LinearLayoutManager.VERTICAL))
+        return root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        rvLicenses.setControllerAndBuildModels(epoxyController)
+    }
+
+    private val epoxyController: EpoxyController = simpleController {
+        licenses.map { licenseEntry ->
+            licenseView {
+                id(licenseEntry.key)
+                license(licenseEntry.key)
+                onClick { _ ->
+                    Intent().apply {
+                        action = Intent.ACTION_VIEW
+                        data = Uri.parse(licenseEntry.value)
+                    }.also {
+                        startActivity(it)
+                    }
+                }
+            }
+        }
+    }
+}

--- a/about/src/main/java/com/haroldadmin/moonshot/about/views/LicenseView.kt
+++ b/about/src/main/java/com/haroldadmin/moonshot/about/views/LicenseView.kt
@@ -1,0 +1,45 @@
+package com.haroldadmin.moonshot.about.views
+
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.util.AttributeSet
+import android.widget.FrameLayout
+import androidx.appcompat.widget.AppCompatTextView
+import com.airbnb.epoxy.CallbackProp
+import com.airbnb.epoxy.ModelProp
+import com.airbnb.epoxy.ModelView
+import com.airbnb.epoxy.OnViewRecycled
+import com.haroldadmin.moonshot.about.R
+import com.haroldadmin.moonshot.utils.asyncText
+
+@ModelView(autoLayout = ModelView.Size.MATCH_WIDTH_WRAP_HEIGHT)
+class LicenseView @JvmOverloads constructor(
+    context: Context,
+    attrs: AttributeSet? = null,
+    defStyleAttr: Int = 0
+) : FrameLayout(context, attrs, defStyleAttr) {
+
+    init {
+        inflate(context, R.layout.view_license, this)
+    }
+
+    private val license: AppCompatTextView = findViewById(R.id.license)
+
+    @ModelProp
+    fun setLicense(name: String) {
+        license.asyncText(name)
+    }
+
+    @CallbackProp
+    fun setOnClick(onClick: OnClickListener?) {
+        if (onClick != null) {
+            rootView.setOnClickListener(onClick)
+        }
+    }
+
+    @OnViewRecycled
+    fun cleanup() {
+        rootView.setOnClickListener(null)
+    }
+}

--- a/about/src/main/res/drawable/ic_law.xml
+++ b/about/src/main/res/drawable/ic_law.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="14dp"
+    android:height="16dp"
+    android:viewportWidth="14"
+    android:viewportHeight="16">
+  <path
+      android:fillColor="#FF000000"
+      android:pathData="M7,4c-0.83,0 -1.5,-0.67 -1.5,-1.5S6.17,1 7,1s1.5,0.67 1.5,1.5S7.83,4 7,4zM14,10c0,1.11 -0.89,2 -2,2h-1c-1.11,0 -2,-0.89 -2,-2l2,-4h-1c-0.55,0 -1,-0.45 -1,-1L8,5v8c0.42,0 1,0.45 1,1h1c0.42,0 1,0.45 1,1L3,15c0,-0.55 0.58,-1 1,-1h1c0,-0.55 0.58,-1 1,-1h0.03L6,5L5,5c0,0.55 -0.45,1 -1,1L3,6l2,4c0,1.11 -0.89,2 -2,2L2,12c-1.11,0 -2,-0.89 -2,-2l2,-4L1,6L1,5h3c0,-0.55 0.45,-1 1,-1h4c0.55,0 1,0.45 1,1h3v1h-1l2,4zM2.5,7L1,10h3L2.5,7zM13,10l-1.5,-3 -1.5,3h3z"
+      android:fillType="evenOdd"/>
+</vector>

--- a/about/src/main/res/layout/fragment_licenses.xml
+++ b/about/src/main/res/layout/fragment_licenses.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/colorSurface">
+
+    <com.airbnb.epoxy.EpoxyRecyclerView
+        android:id="@+id/rvLicenses"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:itemCount="5"
+        tools:listitem="@layout/view_license" />
+
+</FrameLayout>

--- a/about/src/main/res/layout/view_license.xml
+++ b/about/src/main/res/layout/view_license.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<merge xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+    <androidx.appcompat.widget.AppCompatTextView
+        android:id="@+id/license"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:textSize="26sp"
+        android:textColor="?attr/colorOnSurface"
+        android:layout_margin="@dimen/marginLarge"
+        tools:text="AndroidX"/>
+</merge>

--- a/about/src/main/res/values/strings.xml
+++ b/about/src/main/res/values/strings.xml
@@ -12,4 +12,7 @@
     <string name="aboutFragmentApiCreditsMessage">MoonShot is powered by the open source SpaceX API</string>
     <string name="aboutFragmentPrivacyPolicyHeader">Privacy Policy</string>
     <string name="aboutFragmentPrivacyPolicyMessage">Click here to read our privacy policy</string>
+    <string name="openSourceLicensesHeader">Open Source Licenses</string>
+    <string name="openSourceLicensesDetailMessage">Licenses for Open Source libraries used in the app</string>
+    <string name="openSourceLicensesDetailHeader">Open Source Licenses</string>
 </resources>

--- a/app/src/main/res/navigation/nav_graph.xml
+++ b/app/src/main/res/navigation/nav_graph.xml
@@ -124,7 +124,20 @@
         <deepLink
             android:id="@+id/aboutDeepLink"
             app:uri="moonshot://about" />
+        <action
+            android:id="@+id/viewLicenses"
+            app:destination="@id/licenses"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"/>
     </fragment>
+
+    <fragment
+        android:id="@+id/licenses"
+        android:name="com.haroldadmin.moonshot.about.LicensesFragment"
+        android:label="@string/title_licenses"
+        tools:layout="@layout/fragment_licenses"/>
 
     <navigation
         android:id="@+id/launchesFlow"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -32,4 +32,5 @@
     <string name="launchCardHeaderText">Launch</string>
     <string name="launchCardNoMissionNameText">Unknown</string>
     <string name="launchCardNoSiteNameText">Unknown</string>
+    <string name="title_licenses">Licenses</string>
 </resources>


### PR DESCRIPTION
Fixes #15

Adds a very basic licenses list page to the app. This does not look pretty, but gets the job done.