### PR TITLE
Migrate to Kotlin 1.4.0

### DIFF
--- a/buildSrc/src/main/java/ProjectProperties.kt
+++ b/buildSrc/src/main/java/ProjectProperties.kt
@@ -7,7 +7,7 @@ object ProjectProperties {
     const val versionCode = 33
     const val versionName = "0.9.7"
 
-    const val kotlinVersion = "1.3.72"
+    const val kotlinVersion = "1.4.0"
     const val agpVersion = "4.2.0-alpha04"
 
     const val gmsVersion = "4.3.2"

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -22,7 +22,7 @@ object Versions {
     const val openGraphKt = "master-SNAPSHOT"
     const val whatTheStack = "0.0.4"
 
-    const val epoxy = "3.9.0"
+    const val epoxy = "3.10.0"
 
     const val coil = "0.9.2"
 


### PR DESCRIPTION
Epoxy version should be updated due to https://github.com/airbnb/epoxy/issues/956

Closes https://github.com/haroldadmin/MoonShot/issues/31